### PR TITLE
Option for self-hosting, docker deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+build
+.dockerignore
+Dockerfile
+README.md
+CODE_OF_CONDUCT.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# pull official base image
+FROM node:alpine
+
+# set working directory
+WORKDIR /app
+
+# add `/app/node_modules/.bin` to $PATH
+ENV PATH /app/node_modules/.bin:$PATH
+
+# install app dependencies
+COPY package.json ./
+COPY package-lock.json ./
+RUN npm install
+
+# add app
+COPY . ./
+
+# Expose port 3000
+EXPOSE 3000
+
+# start app
+CMD ["npm", "start"]

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,0 +1,15 @@
+# build environment
+FROM node:alpine as builder
+WORKDIR /app
+ENV PATH /app/node_modules/.bin:$PATH
+COPY package.json ./
+COPY package-lock.json ./
+RUN npm install
+COPY . ./
+RUN npm run build
+
+# production environment
+FROM nginx:stable-alpine
+COPY --from=builder /app/build /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 NOTE: This is my recreation of already existing [monkeytype](https://monkeytype.com)
 
-This site is currently live: [Visit Here](https://salmannotkhan.github.io/Typing-Test)
+This site is currently live: [Visit Here](https://salmannotkhan.github.io/typing-test)
 
 ## How to run locally
 
@@ -31,7 +31,7 @@ The **typing-test** app also has a Docker deployment for self-hosting purposes. 
 The `Dockerfile` at the root is the source of building the image. By default **port** `3000` is exposed by the container. You can change it to a different port if require via docker run.
 
 To build the image, you can run,
-`docker built -t typing-test-app .`
+`docker build -t typing-test-app .`
 
 > _Remember, the . (dot) sign is very necessary to provide the build context to the docker runtime._
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,11 @@ The **typing-test** app also has a Docker deployment for self-hosting purposes. 
 
 The `Dockerfile` at the root is the source of building the image. By default **port** `3000` is exposed by the container. You can change it to a different port if require via docker run.
 
-To build the image, you can run,
+To build the image, you can run (development build),
 `docker build -t typing-test-app .`
+
+**For production build use the Dockerfile.prod file** [Port 80 is exposed in production mode]
+`docker build -f Dockerfile.prod -t typing-test-app:prod .`
 
 > _Remember, the . (dot) sign is very necessary to provide the build context to the docker runtime._
 

--- a/README.md
+++ b/README.md
@@ -11,12 +11,40 @@ This site is currently live: [Visit Here](https://salmannotkhan.github.io/Typing
 ## How to run locally
 
 ```zsh
+
 git clone https://github.com/salmannotkhan/typing-test.git
+
 cd typing-test
+
 npm install
-npm start     # to start local server at `localhost:3000`
+
+npm start # to start local server at `localhost:3000`
+
 npm run build # to create production build run
+
 ```
+
+## Local Deployment (Docker 🐳)
+
+The **typing-test** app also has a Docker deployment for self-hosting purposes. Please read below instructions.
+
+The `Dockerfile` at the root is the source of building the image. By default **port** `3000` is exposed by the container. You can change it to a different port if require via docker run.
+
+To build the image, you can run,
+`docker built -t typing-test-app .`
+
+> _Remember, the . (dot) sign is very necessary to provide the build context to the docker runtime._
+
+Wait for some minutes ⏰ for the image to be built
+
+After the image being built, you can list the docker images by
+`docker image ls`
+
+Now run the container to serve it locally on your environment,
+`docker run --name -d typing-test-app -p 8080:3000 typing-test-app`
+
+> -p flag to override the default exposed port (3000 by default)
+> -d flag to detach the container run.
 
 ## Got new theme ideas?
 
@@ -27,27 +55,39 @@ I'll be happy to merge your theme ideas into typing-test. To add new theme:
 ```css
 .theme-name {
 	--bg-color: <background-color here> !important;
+
 	--font-color: <font-color here> !important;
+
 	--hl-color: <highlight-color here> !important;
+
 	--fg-color: <forground-color here> !important;
 }
 ```
 
-> **Note:**  
-> `highlight-color` is used for caret, wrong characters, timer, selected and onhover colors  
-> `forground-color` is used for correctly typed characters  
+> **Note:**
+
+> `highlight-color` is used for caret, wrong characters, timer, selected and onhover colors
+
+> `forground-color` is used for correctly typed characters
+
 > <i>Using hex codes for colors is recommended</i>
 
-2.  Add theme name into `src/components/Header.tsx` in options:
+2. Add theme name into `src/components/Header.tsx` in options:
 
 ```tsx
-const options: Options = {
-	time: [15, 30, 45, 60],
-	theme: ["default", "mkbhd", "coral", "ocean", "azure", "forest", <theme-name>],
+
+const options: Options =  {
+
+time:  [15,  30,  45,  60],
+
+theme:  ["default",  "mkbhd",  "coral",  "ocean",  "azure",  "forest",  <theme-name>],
+
 };
+
 ```
 
-> **Important:**  
+> **Important:**
+
 > theme-name in `themes.scss` and `Header.tsx` should always match otherwise themes won't work
 
 3. Make a pull request

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,7 @@
+version: "3"
+services:
+    typing-test-app:
+        image: typing-test-app
+        ports:
+            - "8080:3000"
+        command: typing-test-app

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,7 +8,15 @@ interface Options {
 
 const options: Options = {
 	time: [15, 30, 45, 60],
-	theme: ["default", "mkbhd", "coral", "ocean", "azure", "forest"],
+	theme: [
+		"default",
+		"mkbhd",
+		"shades-of-purple",
+		"coral",
+		"ocean",
+		"azure",
+		"forest",
+	],
 };
 
 interface Props {

--- a/src/stylesheets/themes.scss
+++ b/src/stylesheets/themes.scss
@@ -32,3 +32,10 @@
 	--hl-color: #c6ffc1 !important;
 	--fg-color: #34656d !important;
 }
+
+.shades-of-purple {
+	--bg-color: #1e1e3f !important;
+	--font-color: #f3d000 !important;
+	--hl-color: #6bd314 !important;
+	--fg-color: gray !important;
+}


### PR DESCRIPTION
Hi! I am making this small PR to provide users options to self-host your typing-test app. Docker 🐳 will survive for the long run and is a much much better option to run in production. Please check this PR and if you like it let me know.

I am so pumped for future contributions to this project, really liked the tool, awesome work buddy.

I have provided a sample `docker-run` command in the README.md and also a `docker-compose.yaml` file in the root of the repo, whichever the user may find easy.